### PR TITLE
[Feature] Support SharedSequenceConvertibleType extension about DriverSharingStrategy

### DIFF
--- a/Example/RxCocoa-Texture.xcodeproj/project.pbxproj
+++ b/Example/RxCocoa-Texture.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9B0E163F210DADB70013EC86 /* ASBinderTestNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0E1638210DADB70013EC86 /* ASBinderTestNode.swift */; };
 		9B0E1642210DADCF0013EC86 /* RepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0E1641210DADCE0013EC86 /* RepositoryViewModel.swift */; };
 		9B6C23932124EB4200129E2F /* RepositoryViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6C23922124EB4200129E2F /* RepositoryViewModel2.swift */; };
+		9BB3ECFE22784059007CE252 /* BinderAndDriver+RxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB3ECFC22783FB7007CE252 /* BinderAndDriver+RxSpec.swift */; };
 		9BE3DFE3211E780600816FD9 /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3DFE2211E780500816FD9 /* ImageDownloader.swift */; };
 		BA5756B9222CC72D00D8CBD9 /* ASDisplayNode+RxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */; };
 		C2B9E94A4FCBBCFCA86BBE1B /* Pods_RxCocoa_Texture_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30C467A356AD9535ACE740C9 /* Pods_RxCocoa_Texture_Tests.framework */; };
@@ -81,6 +82,7 @@
 		9B0E1638210DADB70013EC86 /* ASBinderTestNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASBinderTestNode.swift; sourceTree = "<group>"; };
 		9B0E1641210DADCE0013EC86 /* RepositoryViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel.swift; sourceTree = "<group>"; };
 		9B6C23922124EB4200129E2F /* RepositoryViewModel2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel2.swift; sourceTree = "<group>"; };
+		9BB3ECFC22783FB7007CE252 /* BinderAndDriver+RxSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BinderAndDriver+RxSpec.swift"; sourceTree = "<group>"; };
 		9BE3DFE2211E780500816FD9 /* ImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
 		9E1C79DA561D40B89763472E /* Pods-RxCocoa-Texture_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxCocoa-Texture_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RxCocoa-Texture_Tests/Pods-RxCocoa-Texture_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		A700DE1AE94F129E06542938 /* Pods-RxCocoa-Texture_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxCocoa-Texture_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxCocoa-Texture_Example/Pods-RxCocoa-Texture_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -173,13 +175,14 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */,
 				9B0E15F7210DA33F0013EC86 /* ASButtonNode+RxSpec.swift */,
 				9B0E15F8210DA33F0013EC86 /* ASControlNode+RxSpec.swift */,
+				BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */,
 				9B0E15FA210DA33F0013EC86 /* ASEditableTextNode+RxSpec.swift */,
 				9B0E15FC210DA33F0013EC86 /* ASImageNode+RxSpec.swift */,
 				9B0E15FB210DA33F0013EC86 /* ASNetworkImageNode+RxSpec.swift */,
 				9B0E15F9210DA33F0013EC86 /* ASTextNode+RxSpec.swift */,
+				9BB3ECFC22783FB7007CE252 /* BinderAndDriver+RxSpec.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -515,6 +518,7 @@
 			files = (
 				BA5756B9222CC72D00D8CBD9 /* ASDisplayNode+RxSpec.swift in Sources */,
 				9B0E1607210DA3E80013EC86 /* ASEditableTextNode+RxSpec.swift in Sources */,
+				9BB3ECFE22784059007CE252 /* BinderAndDriver+RxSpec.swift in Sources */,
 				9B0E1606210DA3E50013EC86 /* ASControlNode+RxSpec.swift in Sources */,
 				9B0E1603210DA3CE0013EC86 /* ASImageNode+RxSpec.swift in Sources */,
 				9B0E1609210DA3F00013EC86 /* ASTextNode+RxSpec.swift in Sources */,

--- a/Example/RxCocoa-Texture/ASBinderTestNode.swift
+++ b/Example/RxCocoa-Texture/ASBinderTestNode.swift
@@ -15,6 +15,10 @@ class ASBinderTestNode: ASDisplayNode {
     
     let textNode =  ASTextNode()
     let imageNode = ASNetworkImageNode()
+    
+    let textNode2 =  ASTextNode()
+    let imageNode2 = ASNetworkImageNode()
+    
     let disposeBag = DisposeBag()
     let url = URL(string: "https://koreaboo-cdn.storage.googleapis.com/2017/08/sana-1-1.jpg")
     
@@ -28,6 +32,14 @@ class ASBinderTestNode: ASDisplayNode {
         
         Observable.just(Optional<String>("optional text"))
             .bind(to: textNode.rx.text(nil), setNeedsLayout: self)
+            .disposed(by: disposeBag)
+        
+        Driver.just(url)
+            .drive(imageNode2.rx.url, setNeedsLayout: self)
+            .disposed(by: disposeBag)
+        
+        Driver.just(Optional<String>("optional test"))
+            .drive(textNode2.rx.text(nil), setNeedsLayout: self)
             .disposed(by: disposeBag)
     }
 }

--- a/Example/Tests/BinderAndDriver+RxSpec.swift
+++ b/Example/Tests/BinderAndDriver+RxSpec.swift
@@ -1,0 +1,80 @@
+//
+//  BinderAndDriver+RxSpec.swift
+//
+//  Created by Geektree0101.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Quick
+import Nimble
+import RxTest
+import RxSwift
+import RxCocoa
+import AsyncDisplayKit
+@testable import RxCocoa_Texture
+
+class BinderAndDriver_RxExtensionSpec: QuickSpec {
+    
+    override func spec() {
+        
+        var disposeBag = DisposeBag()
+        
+        describe("Bind Test") {
+            let textNode = ASTextNode()
+            let textNode2 = ASTextNode()
+            let textNode3 = ASTextNode()
+            
+            beforeEach {
+                disposeBag = DisposeBag()
+                
+                Observable.just("test")
+                    .bind(to: textNode.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+                
+                Observable.just("test2")
+                    .bind(to: textNode2.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+                
+                Observable.just("test3")
+                    .bind(to: textNode3.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+            }
+            
+            it("should be bind estimated value") {
+                
+                expect(textNode.attributedText!.string).to(equal("test"))
+                expect(textNode2.attributedText!.string).to(equal("test2"))
+                expect(textNode3.attributedText!.string).to(equal("test3"))
+            }
+        }
+        
+        describe("Drive Test") {
+            let textNode = ASTextNode()
+            let textNode2 = ASTextNode()
+            let textNode3 = ASTextNode()
+            
+            beforeEach {
+                disposeBag = DisposeBag()
+                
+                Driver.just("test")
+                    .drive(textNode.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+                
+                Driver.just("test2")
+                    .drive(textNode2.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+                
+                Driver.just("test3")
+                    .drive(textNode3.rx.text(nil), setNeedsLayout: nil)
+                    .disposed(by: disposeBag)
+            }
+            
+            it("should be drive estimated value") {
+                
+                expect(textNode.attributedText!.string).to(equal("test"))
+                expect(textNode2.attributedText!.string).to(equal("test2"))
+                expect(textNode3.attributedText!.string).to(equal("test3"))
+            }
+        }
+    }
+}

--- a/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
+++ b/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
@@ -1,0 +1,38 @@
+//
+//  ASNetworkImageNode+Rx.swift
+//
+//  Created by Geektree0101.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import AsyncDisplayKit
+import RxSwift
+import RxCocoa
+
+private let errorMessage = "`drive*` family of methods can be only called from `MainThread`.\n" +
+"This is required to ensure that the last replayed `Driver` element is delivered on `MainThread`.\n"
+
+extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingStrategy {
+    
+    public func drive<O: ASObserverType>(_ observer: O,
+                                         directlyBind: Bool = false,
+                                         setNeedsLayout node: ASDisplayNode? = nil) -> Disposable where O.E == E {
+        MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
+        return self.asSharedSequence()
+            .asObservable()
+            .bind(to: observer,
+                  directlyBind: directlyBind,
+                  setNeedsLayout: node)
+    }
+    
+    public func drive<O: ASObserverType>(_ observer: O,
+                                         directlyBind: Bool = false,
+                                         setNeedsLayout node: ASDisplayNode? = nil) -> Disposable where O.E == E? {
+        MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
+        return self.asSharedSequence()
+            .asObservable()
+            .bind(to: observer,
+                  directlyBind: directlyBind,
+                  setNeedsLayout: node)
+    }
+}

--- a/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
+++ b/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
@@ -31,6 +31,7 @@ extension SharedSequenceConvertibleType where SharingStrategy == DriverSharingSt
         MainScheduler.ensureExecutingOnScheduler(errorMessage: errorMessage)
         return self.asSharedSequence()
             .asObservable()
+            .map { $0 as E? }
             .bind(to: observer,
                   directlyBind: directlyBind,
                   setNeedsLayout: node)

--- a/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
+++ b/RxCocoa-Texture/Classes/Driver+ASSubscription.swift
@@ -1,5 +1,5 @@
 //
-//  ASNetworkImageNode+Rx.swift
+//  Driver+ASSubscription.swift
 //
 //  Created by Geektree0101.
 //  Copyright © 2018 RxSwiftCommunity. All rights reserved.


### PR DESCRIPTION
### New Feature

Now RxCocoa-Texture support SharedSequenceConvertibleType extension about DriverSharingStrategy

```swift

        Driver.just(url)
            .drive(imageNode2.rx.url, setNeedsLayout: self)
            .disposed(by: disposeBag)
        
        Driver.just(Optional<String>("optional test"))
            .drive(textNode2.rx.text(nil), setNeedsLayout: self)
            .disposed(by: disposeBag)
```

@OhKanghoon plz review this PR :) thank you

