### PR TITLE
[Feature] Support ASTextNode2 Extension

### DIFF
--- a/Example/RxCocoa-Texture.xcodeproj/project.pbxproj
+++ b/Example/RxCocoa-Texture.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		9B0E163F210DADB70013EC86 /* ASBinderTestNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0E1638210DADB70013EC86 /* ASBinderTestNode.swift */; };
 		9B0E1642210DADCF0013EC86 /* RepositoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B0E1641210DADCE0013EC86 /* RepositoryViewModel.swift */; };
 		9B6C23932124EB4200129E2F /* RepositoryViewModel2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6C23922124EB4200129E2F /* RepositoryViewModel2.swift */; };
+		9BB3ED02227842C5007CE252 /* ASTextNode2+RxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB3ED01227842C5007CE252 /* ASTextNode2+RxSpec.swift */; };
 		9BE3DFE3211E780600816FD9 /* ImageDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BE3DFE2211E780500816FD9 /* ImageDownloader.swift */; };
 		BA5756B9222CC72D00D8CBD9 /* ASDisplayNode+RxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */; };
 		C2B9E94A4FCBBCFCA86BBE1B /* Pods_RxCocoa_Texture_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 30C467A356AD9535ACE740C9 /* Pods_RxCocoa_Texture_Tests.framework */; };
@@ -81,6 +82,7 @@
 		9B0E1638210DADB70013EC86 /* ASBinderTestNode.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ASBinderTestNode.swift; sourceTree = "<group>"; };
 		9B0E1641210DADCE0013EC86 /* RepositoryViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel.swift; sourceTree = "<group>"; };
 		9B6C23922124EB4200129E2F /* RepositoryViewModel2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RepositoryViewModel2.swift; sourceTree = "<group>"; };
+		9BB3ED01227842C5007CE252 /* ASTextNode2+RxSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ASTextNode2+RxSpec.swift"; sourceTree = "<group>"; };
 		9BE3DFE2211E780500816FD9 /* ImageDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloader.swift; sourceTree = "<group>"; };
 		9E1C79DA561D40B89763472E /* Pods-RxCocoa-Texture_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxCocoa-Texture_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RxCocoa-Texture_Tests/Pods-RxCocoa-Texture_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		A700DE1AE94F129E06542938 /* Pods-RxCocoa-Texture_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RxCocoa-Texture_Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-RxCocoa-Texture_Example/Pods-RxCocoa-Texture_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -173,13 +175,14 @@
 		607FACE81AFB9204008FA782 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */,
 				9B0E15F7210DA33F0013EC86 /* ASButtonNode+RxSpec.swift */,
 				9B0E15F8210DA33F0013EC86 /* ASControlNode+RxSpec.swift */,
+				BA5756B7222CC72200D8CBD9 /* ASDisplayNode+RxSpec.swift */,
 				9B0E15FA210DA33F0013EC86 /* ASEditableTextNode+RxSpec.swift */,
 				9B0E15FC210DA33F0013EC86 /* ASImageNode+RxSpec.swift */,
 				9B0E15FB210DA33F0013EC86 /* ASNetworkImageNode+RxSpec.swift */,
 				9B0E15F9210DA33F0013EC86 /* ASTextNode+RxSpec.swift */,
+				9BB3ED01227842C5007CE252 /* ASTextNode2+RxSpec.swift */,
 				607FACE91AFB9204008FA782 /* Supporting Files */,
 			);
 			path = Tests;
@@ -517,6 +520,7 @@
 				9B0E1607210DA3E80013EC86 /* ASEditableTextNode+RxSpec.swift in Sources */,
 				9B0E1606210DA3E50013EC86 /* ASControlNode+RxSpec.swift in Sources */,
 				9B0E1603210DA3CE0013EC86 /* ASImageNode+RxSpec.swift in Sources */,
+				9BB3ED02227842C5007CE252 /* ASTextNode2+RxSpec.swift in Sources */,
 				9B0E1609210DA3F00013EC86 /* ASTextNode+RxSpec.swift in Sources */,
 				9B0E1605210DA3E30013EC86 /* ASButtonNode+RxSpec.swift in Sources */,
 				9B0E1608210DA3ED0013EC86 /* ASNetworkImageNode+RxSpec.swift in Sources */,

--- a/Example/Tests/ASTextNode2+RxSpec.swift
+++ b/Example/Tests/ASTextNode2+RxSpec.swift
@@ -1,0 +1,58 @@
+//
+//  ASTextNode2+RxExtensionSpec.swift
+//
+//  Created by Geektree0101.
+//  Copyright © 2018 RxSwiftCommunity. All rights reserved.
+//
+
+import Quick
+import Nimble
+import RxTest
+import RxSwift
+import RxCocoa
+import AsyncDisplayKit
+@testable import RxCocoa_Texture
+
+class ASTextNode2_RxExtensionSpecSpec: QuickSpec {
+    
+    override func spec() {
+        
+        context("ASTextNode Reactive Extension  Unit Test") {
+            
+            let textNode1 = ASTextNode2()
+            let textNode2 = ASTextNode2()
+            let textNode3 = ASTextNode2()
+            let textNode4 = ASTextNode2()
+            
+            let disposeBag = DisposeBag()
+            
+            beforeEach {
+                Observable.just("apple")
+                    .bind(to: textNode1.rx.text([:]))
+                    .disposed(by: disposeBag)
+                
+                Observable.just(nil)
+                    .bind(to: textNode2.rx.text([:]))
+                    .disposed(by: disposeBag)
+                
+                Observable.just("banana")
+                    .map({ NSAttributedString(string: $0) })
+                    .bind(to: textNode3.rx.attributedText)
+                    .disposed(by: disposeBag)
+                
+                Observable.just(nil)
+                    .bind(to: textNode4.rx.attributedText)
+                    .disposed(by: disposeBag)
+            }
+            
+            it("should be emit expected event") {
+                
+                expect(textNode1.attributedText?.string).to(equal("apple"))
+                expect(textNode2.attributedText?.string).to(equal(""))
+                expect(textNode3.attributedText?.string).to(equal("banana"))
+                expect(textNode4.attributedText?.string).to(equal(""))
+            }
+        }
+    }
+}
+

--- a/Example/Tests/ASTextNode2+RxSpec.swift
+++ b/Example/Tests/ASTextNode2+RxSpec.swift
@@ -13,6 +13,8 @@ import RxCocoa
 import AsyncDisplayKit
 @testable import RxCocoa_Texture
 
+#if AS_ENABLE_TEXTNODE
+
 class ASTextNode2_RxExtensionSpecSpec: QuickSpec {
     
     override func spec() {
@@ -56,3 +58,4 @@ class ASTextNode2_RxExtensionSpecSpec: QuickSpec {
     }
 }
 
+#endif

--- a/RxCocoa-Texture/Classes/ASTextNode+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASTextNode+Rx.swift
@@ -9,12 +9,6 @@ import AsyncDisplayKit
 import RxSwift
 import RxCocoa
 
-#if (!AS_ENABLE_TEXTNODE)
-
-// Pull in ASTextNode2 to replace ASTextNode with ASTextNode2
-
-#else
-
 extension Reactive where Base: ASTextNode {
     
     public var attributedText: ASBinder<NSAttributedString?> {
@@ -37,5 +31,3 @@ extension Reactive where Base: ASTextNode {
         }
     }
 }
-
-#endif

--- a/RxCocoa-Texture/Classes/ASTextNode2+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASTextNode2+Rx.swift
@@ -9,6 +9,8 @@ import AsyncDisplayKit
 import RxSwift
 import RxCocoa
 
+#if (!AS_ENABLE_TEXTNODE)
+
 extension Reactive where Base: ASTextNode2 {
     
     public var attributedText: ASBinder<NSAttributedString?> {
@@ -31,3 +33,5 @@ extension Reactive where Base: ASTextNode2 {
         }
     }
 }
+
+#endif

--- a/RxCocoa-Texture/Classes/ASTextNode2+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASTextNode2+Rx.swift
@@ -1,5 +1,5 @@
 //
-//  ASTextNode+Rx.swift
+//  ASTextNode2+Rx.swift
 //
 //  Created by Geektree0101.
 //  Copyright © 2018 RxSwiftCommunity. All rights reserved.
@@ -9,13 +9,7 @@ import AsyncDisplayKit
 import RxSwift
 import RxCocoa
 
-#if (!AS_ENABLE_TEXTNODE)
-
-// Pull in ASTextNode2 to replace ASTextNode with ASTextNode2
-
-#else
-
-extension Reactive where Base: ASTextNode {
+extension Reactive where Base: ASTextNode2 {
     
     public var attributedText: ASBinder<NSAttributedString?> {
         
@@ -23,7 +17,7 @@ extension Reactive where Base: ASTextNode {
             node.attributedText = attributedText
         }
     }
-
+    
     public func text(_ attributes: [NSAttributedString.Key: Any]?) -> ASBinder<String?> {
         
         return ASBinder(self.base) { node, text in
@@ -37,5 +31,3 @@ extension Reactive where Base: ASTextNode {
         }
     }
 }
-
-#endif


### PR DESCRIPTION
### New Feature!

Now RxCocoa-Texture support ASTextNode2 extension
Be careful use **AS_ENABLE_TEXTNODE** preprocessor definition (default is YES)
Usage is equal with ASTextNode :) 

```swift
let textNode1 = ASTextNode2()
let disposeBag = DisposeBag()
            
Observable.just("apple")
                   .bind(to: textNode1.rx.text([:]))
                   .disposed(by: disposeBag)
```