### PR TITLE
Convert ASControlNode.rx.isHighlighted to ControlProperty

### DIFF
--- a/Example/Tests/ASControlNode+RxSpec.swift
+++ b/Example/Tests/ASControlNode+RxSpec.swift
@@ -187,6 +187,28 @@ class ASControlNode_RxExtensionSpecSpec: QuickSpec {
                 
                 expect(controlNode.isHighlighted).to(beFalse())
             }
+
+            it("should observe highlight/unhighlight") {
+
+                // given
+                var isHighlighted: Bool = false
+                controlNode.isEnabled = true
+                controlNode.rx.isHighlighted
+                    .subscribe(onNext: { isHighlighted = $0 })
+                    .disposed(by: disposedBag)
+
+                // when & then - Touch down/up/cancel
+                controlNode.touchesBegan([UITouch()], with: nil)
+                expect(isHighlighted).to(beTrue())
+
+                controlNode.touchesBegan([UITouch()], with: nil)
+                controlNode.touchesEnded([UITouch()], with: nil)
+                expect(isHighlighted).to(beFalse())
+
+                controlNode.touchesBegan([UITouch()], with: nil)
+                controlNode.touchesCancelled([UITouch()], with: nil)
+                expect(isHighlighted).to(beFalse())
+            }
             
             it("should be selected/non-selected") {
                 

--- a/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
@@ -100,19 +100,16 @@ extension Reactive where Base: ASControlNode {
     
     public var isHighlighted: ControlProperty<Bool> {
 
-      let source = self
-        .methodInvoked(#selector(setter: ASControlNode.isHighlighted))
-        .map { [weak base] _ in base?.isHighlighted }
-        .flatMap { _isHighlighted -> Observable<Bool> in
-          guard let isHighlighted = _isHighlighted else { return Observable.empty() }
-          return Observable.just(isHighlighted)
-        }
-
-      let binder = ASBinder(self.base) { node, isHighlighted in
-        node.isHighlighted = isHighlighted
-      }
-
-      return ControlProperty(values: source, valueSink: binder)
+        // .touchDownRepeat becaused of ASControlNode.touchesBegan(_:with:)
+        return self.controlProperty(
+            editingEvents: [.touchDown, .touchDownRepeat, .touchUpInside, .touchCancel],
+            getter: { control in
+                control.isHighlighted
+            },
+            setter: { control, isHighlighted in
+                control.isHighlighted = isHighlighted
+            }
+        )
     }
     
     public var isSelected: ASBinder<Bool> {

--- a/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
@@ -98,11 +98,21 @@ extension Reactive where Base: ASControlNode {
         }
     }
     
-    public var isHighlighted: ASBinder<Bool> {
-        
-        return ASBinder(self.base) { node, isHighlighted in
-            node.isHighlighted = isHighlighted
+    public var isHighlighted: ControlProperty<Bool> {
+
+      let source = self
+        .methodInvoked(#selector(setter: ASControlNode.isHighlighted))
+        .map { [weak base] _ in base?.isHighlighted }
+        .flatMap { _isHighlighted -> Observable<Bool> in
+          guard let isHighlighted = _isHighlighted else { return Observable.empty() }
+          return Observable.just(isHighlighted)
         }
+
+      let binder = ASBinder(self.base) { node, isHighlighted in
+        node.isHighlighted = isHighlighted
+      }
+
+      return ControlProperty(values: source, valueSink: binder)
     }
     
     public var isSelected: ASBinder<Bool> {


### PR DESCRIPTION
I need to observe `isHighlighted` of an `ASControlNode` instance to change the state of another node. (Like the situation that I want to show the dimmed `ASDisplayNode` when I'm pressing a `ASControlNode`)

That's why propose this because there is a solution for this situation ☺️

This change is tested on our company's project at least (the feature where I'm working on).