### PR TITLE
Remove unnecessary .touchDownRepeat event from rx.isHighlighted

### DIFF
--- a/Example/Tests/ASControlNode+RxSpec.swift
+++ b/Example/Tests/ASControlNode+RxSpec.swift
@@ -189,6 +189,17 @@ class ASControlNode_RxExtensionSpecSpec: QuickSpec {
             }
 
             it("should observe highlight/unhighlight") {
+                final class UITouchStub: UITouch {
+                    private let _tapCount: Int
+                    override var tapCount: Int {
+                        return self._tapCount
+                    }
+
+                    override init() {
+                        self._tapCount = 1 // becaused of ASControlNode.touchesBegan(_:with:)
+                        super.init()
+                    }
+                }
 
                 // given
                 var isHighlighted: Bool = false
@@ -198,15 +209,15 @@ class ASControlNode_RxExtensionSpecSpec: QuickSpec {
                     .disposed(by: disposedBag)
 
                 // when & then - Touch down/up/cancel
-                controlNode.touchesBegan([UITouch()], with: nil)
+                controlNode.touchesBegan([UITouchStub()], with: nil)
                 expect(isHighlighted).to(beTrue())
 
-                controlNode.touchesBegan([UITouch()], with: nil)
-                controlNode.touchesEnded([UITouch()], with: nil)
+                controlNode.touchesBegan([UITouchStub()], with: nil)
+                controlNode.touchesEnded([UITouchStub()], with: nil)
                 expect(isHighlighted).to(beFalse())
 
-                controlNode.touchesBegan([UITouch()], with: nil)
-                controlNode.touchesCancelled([UITouch()], with: nil)
+                controlNode.touchesBegan([UITouchStub()], with: nil)
+                controlNode.touchesCancelled([UITouchStub()], with: nil)
                 expect(isHighlighted).to(beFalse())
             }
             

--- a/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
+++ b/RxCocoa-Texture/Classes/ASControlNode+Rx.swift
@@ -100,9 +100,8 @@ extension Reactive where Base: ASControlNode {
     
     public var isHighlighted: ControlProperty<Bool> {
 
-        // .touchDownRepeat becaused of ASControlNode.touchesBegan(_:with:)
         return self.controlProperty(
-            editingEvents: [.touchDown, .touchDownRepeat, .touchUpInside, .touchCancel],
+            editingEvents: [.touchDown, .touchUpInside, .touchCancel],
             getter: { control in
                 control.isHighlighted
             },


### PR DESCRIPTION
## Context 

- I added `.touchDownRepeat` in #23 for test environment. 
  ```objc
  - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
  {
      ...

      // Send the appropriate touch-down control event depending on how many times we've been tapped.
      ASControlNodeEvent controlEventMask = (theTouch.tapCount == 1) ? ASControlNodeEventTouchDown : ASControlNodeEventTouchDownRepeat;
      [self sendActionsForControlEvents:controlEventMask withEvent:event];
    }
  }
  ```

- But it's not needed in production environment.

## Changes

- Created `UITouchStub` internal class only for the spec which tests observing `isHighlighted`
  - It overrides `tapCount` so that `tapCount` can be manipulated
- Did some workaround with `UITouchStub` to pass the test
- Remove unnecessary `.touchDownRepeat` event from `rx.isHighlighted`